### PR TITLE
dApp's methods calls

### DIFF
--- a/dapp_methods_calls.py
+++ b/dapp_methods_calls.py
@@ -1,13 +1,11 @@
 from pyteal import *
 
 
-def methods_calls(methods: list, methods_branches: list):
-
-    assert len(methods) == len(methods_branches)
+def methods_calls(methods: dict):
 
     args = []
-    for i in range(len(methods)):
-        args += [[Txn.application_args[0] == methods[i], methods_branches[i]]]
+    for method_name, method_call in methods.items():
+        args += [[Txn.application_args[0] == Bytes(method_name), method_call]]
 
     precondition = And(
         Txn.type_enum() == TxnType.ApplicationCall,
@@ -42,16 +40,10 @@ if __name__ == "__main__":
         return Return(Int(1))
 
 
-    methods = [
-        Bytes("methodA"),
-        Bytes("methodB"),
-        Bytes("methodC"),
-    ]
+    methods = {
+        'methodA': method_a(),
+        'methodB': method_b(),
+        'methodC': method_c(),
+    }
 
-    methods_branches = [
-        method_a(),
-        method_b(),
-        method_c(),
-    ]
-
-    teal = compile_stateful(methods_calls(methods, methods_branches))
+    teal = compile_stateful(methods_calls(methods))

--- a/dapp_methods_calls.py
+++ b/dapp_methods_calls.py
@@ -1,0 +1,57 @@
+from pyteal import *
+
+
+def methods_calls(methods: list, methods_branches: list):
+
+    assert len(methods) == len(methods_branches)
+
+    args = []
+    for i in range(len(methods)):
+        args += [[Txn.application_args[0] == methods[i], methods_branches[i]]]
+
+    precondition = And(
+        Txn.type_enum() == TxnType.ApplicationCall,
+        Txn.rekey_to() == Global.zero_address(),
+        Txn.application_args.length() >= Int(1),
+    )
+
+    return Seq([
+        Assert(precondition),
+        Cond(*args),
+        Return(Int(1)),
+    ])
+
+
+if __name__ == "__main__":
+
+    TEAL_VERSION = 3
+
+    def compile_stateful(program):
+        return compileTeal(program, Mode.Application, version=TEAL_VERSION)
+
+
+    def method_a():
+        return Return(Int(1))
+
+
+    def method_b():
+        return Return(Int(1))
+
+
+    def method_c():
+        return Return(Int(1))
+
+
+    methods = [
+        Bytes("methodA"),
+        Bytes("methodB"),
+        Bytes("methodC"),
+    ]
+
+    methods_branches = [
+        method_a(),
+        method_b(),
+        method_c(),
+    ]
+
+    teal = compile_stateful(methods_calls(methods, methods_branches))


### PR DESCRIPTION
This PR proposes the `methods_calls()` utility function to facilitate dApps' methods calls dispatching, in compliance with the [ARC-4](https://github.com/jannotti/ARCs/blob/abi/ARCs/arc-0004.md#methods). The utility function ensures some preconditions are also met by the invoking Application Call transactions.

Given the methods' dictionary:

```python
methods = {
    'methodA': method_a(),
    'methodB': method_b(),
    'methodC': method_c(),
}
```

And the method's call offset `call_idx` in a group transaction, `methods_calls(methods: dict, call_idx: int)` utility function could be invoked as:

```python
Cond(
    ...
    [Gtxn[call_idx].on_completion() == OnComplete.NoOp, methods_calls(methods, call_idx)],
    ...
)
```

Producing the following TEAL (v3) methods' dispatching logic:

```
#pragma version 3
gtxn 0 OnCompletion
int NoOp
==
bnz l2
err
l2:
gtxn 0 TypeEnum
int appl
==
gtxn 0 NumAppArgs
int 1
>=
&&
assert
gtxna 0 ApplicationArgs 0
byte "methodA"
==
bnz l8
gtxna 0 ApplicationArgs 0
byte "methodB"
==
bnz l7
gtxna 0 ApplicationArgs 0
byte "methodC"
==
bnz l6
err
l6:
int 1
return
l7:
int 1
return
l8:
int 1
return
int 1
return
```
