### PR TITLE
Adding Matcher for Transaction Filters

### DIFF
--- a/.github/workflows/pyteal-utils-build-test.yaml
+++ b/.github/workflows/pyteal-utils-build-test.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9.9
+        python-version: 3.9.10
 
     - name: Set up Poetry
       uses: abatilo/actions-poetry@v2.1.0

--- a/pytealutils/transaction/match.py
+++ b/pytealutils/transaction/match.py
@@ -13,6 +13,7 @@ from pyteal import (
     TxnField,
     TxnType,
 )
+
 # Common field checks
 
 NoRekey = {TxnField.rekey_to: Global.zero_address()}
@@ -26,6 +27,7 @@ AssetConfig = {TxnField.type_enum: TxnType.AssetConfig}
 
 ToMe = {TxnField.receiver: Global.current_application_address()}
 FromMe = {TxnField.sender: Global.current_application_address()}
+
 
 def PaymentAmount(amount: Union[int, Int]) -> Dict[TxnField, Expr]:
     if type(amount) == int:
@@ -49,6 +51,7 @@ class Match(Expr):
     """Match checks a transaction group against a set of transaction field to expression mapping.
 
     """
+
     def __init__(self, *txns: Dict[TxnField, Expr]):
         filters = []
         for idx, txn in enumerate(txns):
@@ -67,4 +70,3 @@ class Match(Expr):
 
     def __str__(self):
         return "Matcher TODO..."
-

--- a/pytealutils/transaction/match.py
+++ b/pytealutils/transaction/match.py
@@ -30,6 +30,7 @@ AssetConfig = {TxnField.type_enum: TxnType.AssetConfig}
 ToMe = {TxnField.receiver: Global.current_application_address()}
 FromMe = {TxnField.sender: Global.current_application_address()}
 
+
 def PaymentAmount(amount: Union[int, Int]) -> Dict[TxnField, Expr]:
     if type(amount) == int:
         amount = Int(amount)
@@ -70,4 +71,4 @@ class Match(Expr):
         return self.value.__teal__(options)
 
     def __str__(self):
-        return "Match({})"+self.value.__str__()
+        return "Match({})" + self.value.__str__()

--- a/pytealutils/transaction/match.py
+++ b/pytealutils/transaction/match.py
@@ -40,7 +40,7 @@ def PaymentAmount(amount: Union[int, Int]) -> Dict[TxnField, Expr]:
 def AssetIdAndAmount(
     id: Union[int, Int], amount: Union[int, Int]
 ) -> Dict[TxnField, Expr]:
-    if type(id) == int:
+    if type(id) is int:
         id = Int(id)
 
     if type(amount) == int:

--- a/pytealutils/transaction/match.py
+++ b/pytealutils/transaction/match.py
@@ -13,11 +13,43 @@ from pyteal import (
     TxnField,
     TxnType,
 )
+# Common field checks
+
+NoRekey = {TxnField.rekey_to: Global.zero_address()}
+NoCloseTo = {TxnField.close_remainder_to: Global.zero_address()}
+NoCloseAsset = {TxnField.asset_close_to: Global.zero_address()}
+Common = {**NoRekey, **NoCloseTo, **NoCloseAsset}
+
+Payment = {TxnField.type_enum: TxnType.Payment}
+AssetTransfer = {TxnField.type_enum: TxnType.AssetTransfer}
+AssetConfig = {TxnField.type_enum: TxnType.AssetConfig}
+
+ToMe = {TxnField.receiver: Global.current_application_address()}
+FromMe = {TxnField.sender: Global.current_application_address()}
+
+def PaymentAmount(amount: Union[int, Int]) -> Dict[TxnField, Expr]:
+    if type(amount) == int:
+        amount = Int(amount)
+    return {**Payment, TxnField.amount: amount}
+
+
+def AssetIdAndAmount(
+    id: Union[int, Int], amount: Union[int, Int]
+) -> Dict[TxnField, Expr]:
+    if type(id) == int:
+        id = Int(id)
+
+    if type(amount) == int:
+        amount = Int(amount)
+
+    return {**AssetTransfer, TxnField.xfer_asset: id, TxnField.asset_amount: amount}
 
 
 class Match(Expr):
-    def __init__(self, *txns: Dict[TxnField, Expr]):
+    """Match checks a transaction group against a set of transaction field to expression mapping.
 
+    """
+    def __init__(self, *txns: Dict[TxnField, Expr]):
         filters = []
         for idx, txn in enumerate(txns):
             filters.append(And(*[GtxnExpr(idx, k) == v for k, v in txn.items()]))
@@ -36,33 +68,3 @@ class Match(Expr):
     def __str__(self):
         return "Matcher TODO..."
 
-
-NoRekey = {TxnField.rekey_to: Global.zero_address()}
-NoCloseTo = {TxnField.close_remainder_to: Global.zero_address()}
-NoCloseAsset = {TxnField.asset_close_to: Global.zero_address()}
-Common = {**NoRekey, **NoCloseTo, **NoCloseAsset}
-
-Payment = {TxnField.type_enum: TxnType.Payment}
-AssetTransfer = {TxnField.type_enum: TxnType.AssetTransfer}
-AssetConfig = {TxnField.type_enum: TxnType.AssetConfig}
-
-ToMe = {TxnField.receiver: Global.current_application_address()}
-FromMe = {TxnField.sender: Global.current_application_address()}
-
-
-def PaymentAmount(amount: Union[int, Int]) -> Dict[TxnField, Expr]:
-    if type(amount) == int:
-        amount = Int(amount)
-    return {**Payment, TxnField.amount: amount}
-
-
-def AssetIdAndAmount(
-    id: Union[int, Int], amount: Union[int, Int]
-) -> Dict[TxnField, Expr]:
-    if type(id) == int:
-        id = Int(id)
-
-    if type(amount) == int:
-        amount = Int(amount)
-
-    return {**AssetTransfer, TxnField.xfer_asset: id, TxnField.asset_amount: amount}

--- a/pytealutils/transaction/match.py
+++ b/pytealutils/transaction/match.py
@@ -1,21 +1,31 @@
-from typing import Dict, Union, Tuple
-from pyteal import *
+from typing import Dict, Tuple, Union
+
+from pyteal import (
+    And,
+    CompileOptions,
+    Expr,
+    Global,
+    GtxnExpr,
+    Int,
+    TealBlock,
+    TealSimpleBlock,
+    TealType,
+    TxnField,
+    TxnType,
+)
 
 
 class Match(Expr):
-
     def __init__(self, *txns: Dict[TxnField, Expr]):
 
         filters = []
         for idx, txn in enumerate(txns):
-            filters.append(And(*[
-                GtxnExpr(idx, k) == v for k,v in txn.items()
-            ]))
+            filters.append(And(*[GtxnExpr(idx, k) == v for k, v in txn.items()]))
 
         self.value = And(*filters)
 
     def type_of(self) -> TealType:
-        return self.value.type_of() 
+        return self.value.type_of()
 
     def has_return(self) -> bool:
         return self.value.has_return()
@@ -40,6 +50,12 @@ ToMe = {TxnField.receiver: Global.current_application_address()}
 FromMe = {TxnField.sender: Global.current_application_address()}
 
 
+def PaymentAmount(amount: Union[int, Int]) -> Dict[TxnField, Expr]:
+    if type(amount) == int:
+        amount = Int(amount)
+    return {**Payment, TxnField.amount: amount}
+
+
 def AssetIdAndAmount(
     id: Union[int, Int], amount: Union[int, Int]
 ) -> Dict[TxnField, Expr]:
@@ -49,8 +65,4 @@ def AssetIdAndAmount(
     if type(amount) == int:
         amount = Int(amount)
 
-    return {
-        **AssetTransfer,
-        TxnField.xfer_asset: id,
-        TxnField.asset_amount: amount,
-    }
+    return {**AssetTransfer, TxnField.xfer_asset: id, TxnField.asset_amount: amount}

--- a/pytealutils/transaction/match.py
+++ b/pytealutils/transaction/match.py
@@ -1,0 +1,56 @@
+from typing import Dict, Union, Tuple
+from pyteal import *
+
+
+class Match(Expr):
+
+    def __init__(self, *txns: Dict[TxnField, Expr]):
+
+        filters = []
+        for idx, txn in enumerate(txns):
+            filters.append(And(*[
+                GtxnExpr(idx, k) == v for k,v in txn.items()
+            ]))
+
+        self.value = And(*filters)
+
+    def type_of(self) -> TealType:
+        return self.value.type_of() 
+
+    def has_return(self) -> bool:
+        return self.value.has_return()
+
+    def __teal__(self, options: "CompileOptions") -> Tuple[TealBlock, TealSimpleBlock]:
+        return self.value.__teal__(options)
+
+    def __str__(self):
+        return "Matcher TODO..."
+
+
+NoRekey = {TxnField.rekey_to: Global.zero_address()}
+NoCloseTo = {TxnField.close_remainder_to: Global.zero_address()}
+NoCloseAsset = {TxnField.asset_close_to: Global.zero_address()}
+Common = {**NoRekey, **NoCloseTo, **NoCloseAsset}
+
+Payment = {TxnField.type_enum: TxnType.Payment}
+AssetTransfer = {TxnField.type_enum: TxnType.AssetTransfer}
+AssetConfig = {TxnField.type_enum: TxnType.AssetConfig}
+
+ToMe = {TxnField.receiver: Global.current_application_address()}
+FromMe = {TxnField.sender: Global.current_application_address()}
+
+
+def AssetIdAndAmount(
+    id: Union[int, Int], amount: Union[int, Int]
+) -> Dict[TxnField, Expr]:
+    if type(id) == int:
+        id = Int(id)
+
+    if type(amount) == int:
+        amount = Int(amount)
+
+    return {
+        **AssetTransfer,
+        TxnField.xfer_asset: id,
+        TxnField.asset_amount: amount,
+    }

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -1,5 +1,4 @@
 from pyteal import Approve, Arg, Bytes, Cond, Gtxn, Return, TxnField
-from pytest import *
 
 from tests.helpers import *
 

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -1,4 +1,4 @@
-from pyteal import Approve, Cond, Gtxn, Arg, Return, Bytes
+from pyteal import Approve, Arg, Bytes, Cond, Gtxn, Return
 from pytest import *
 
 from tests.helpers import *

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -11,8 +11,7 @@ def test_match():
     payMe = {**Common, **ToMe, **PaymentAmount(100)}
     giveThing = {**Common, **FromMe, **AssetIdAndAmount(10, 100)}
 
-
-    #TODO: I want to add constraints across transactions
+    # TODO: I want to add constraints across transactions
     # ex giveThing.sender == payMe.receiver && payMe.sender == giveThing.receiver
 
     # In cond, check if the txns match and route to the right method, in this case just approve

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -3,7 +3,7 @@ from pytest import *
 
 from tests.helpers import *
 
-from .match import *
+from .match import AssetIdAndAmount, Common, HasMinFee, Match, PaymentAmount
 
 
 def test_match():

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -1,4 +1,4 @@
-from pyteal import Approve, Cond
+from pyteal import Approve, Cond, Gtxn, Arg, Return, Bytes
 from pytest import *
 
 from tests.helpers import *
@@ -7,15 +7,41 @@ from .match import *
 
 
 def test_match():
-    # Swap of algos for asset
-    payMe = {**Common, **ToMe, **PaymentAmount(100)}
-    giveThing = {**Common, **FromMe, **AssetIdAndAmount(10, 100)}
 
-    # TODO: I want to add constraints across transactions
-    # ex giveThing.sender == payMe.receiver && payMe.sender == giveThing.receiver
+    payTxn, giveTxn = Gtxn[0], Gtxn[1]
+    # Swap of algos for asset
+    payMatcher = {
+        **Common,
+        **HasMinFee,
+        **PaymentAmount(amount=100),
+        TxnField.sender: giveTxn.receiver(),
+    }
+    giveMatcher = {
+        **Common,
+        **HasMinFee,
+        **AssetIdAndAmount(id=10, amount=payTxn.amount()),
+        TxnField.sender: payTxn.receiver(),
+    }
+
+
+    # User has a coupon code
+    couponAmount = Int(10)
+    couponCode = {
+        **Common,
+        **HasMinFee,
+        **AssetIdAndAmount(id=10, amount=couponAmount)
+    }
+
+
+    def check_coupon_arg():
+        # prolly use some hash or ed25519 verify thing
+        return  Arg(Int(0)) == Bytes("coupon_code")
 
     # In cond, check if the txns match and route to the right method, in this case just approve
-    expr = Cond([Match(payMe, giveThing), Approve()])
+    expr = Cond(
+        [Match(payMatcher, giveMatcher), Approve()],
+        [Match(couponCode), Return(check_coupon_arg())]
+    )
 
     # No actual testing being done here yet
-    print(compile_app(expr))
+    print(compile_sig(expr))

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -15,4 +15,4 @@ def test_match():
     expr = Cond([Match(payMe, giveThing), Approve()])
 
     # No actual testing being done here yet
-    print(compile_sig(expr))
+    print(compile_app(expr))

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -1,0 +1,8 @@
+from pytest import *
+from tests.helpers import *
+from .match import *
+
+
+def test_match():
+    expr = Seq(Pop(Match(AssetIdAndAmount(10, 100))))
+    print(compile_sig(expr))

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -23,24 +23,18 @@ def test_match():
         TxnField.sender: payTxn.receiver(),
     }
 
-
     # User has a coupon code
     couponAmount = Int(10)
-    couponCode = {
-        **Common,
-        **HasMinFee,
-        **AssetIdAndAmount(id=10, amount=couponAmount)
-    }
-
+    couponCode = {**Common, **HasMinFee, **AssetIdAndAmount(id=10, amount=couponAmount)}
 
     def check_coupon_arg():
         # prolly use some hash or ed25519 verify thing
-        return  Arg(Int(0)) == Bytes("coupon_code")
+        return Arg(Int(0)) == Bytes("coupon_code")
 
     # In cond, check if the txns match and route to the right method, in this case just approve
     expr = Cond(
         [Match(payMatcher, giveMatcher), Approve()],
-        [Match(couponCode), Return(check_coupon_arg())]
+        [Match(couponCode), Return(check_coupon_arg())],
     )
 
     # No actual testing being done here yet

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -1,4 +1,4 @@
-from pyteal import Approve, Arg, Bytes, Cond, Gtxn, Return
+from pyteal import Approve, Arg, Bytes, Cond, Gtxn, Return, TxnField
 from pytest import *
 
 from tests.helpers import *

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -11,6 +11,10 @@ def test_match():
     payMe = {**Common, **ToMe, **PaymentAmount(100)}
     giveThing = {**Common, **FromMe, **AssetIdAndAmount(10, 100)}
 
+
+    #TODO: I want to add constraints across transactions
+    # ex giveThing.sender == payMe.receiver && payMe.sender == giveThing.receiver
+
     # In cond, check if the txns match and route to the right method, in this case just approve
     expr = Cond([Match(payMe, giveThing), Approve()])
 

--- a/pytealutils/transaction/test_match.py
+++ b/pytealutils/transaction/test_match.py
@@ -1,8 +1,18 @@
+from pyteal import Approve, Cond
 from pytest import *
+
 from tests.helpers import *
+
 from .match import *
 
 
 def test_match():
-    expr = Seq(Pop(Match(AssetIdAndAmount(10, 100))))
+    # Swap of algos for asset
+    payMe = {**Common, **ToMe, **PaymentAmount(100)}
+    giveThing = {**Common, **FromMe, **AssetIdAndAmount(10, 100)}
+
+    # In cond, check if the txns match and route to the right method, in this case just approve
+    expr = Cond([Match(payMe, giveThing), Approve()])
+
+    # No actual testing being done here yet
     print(compile_sig(expr))


### PR DESCRIPTION
Most contracts do some basic transaction matching at the beginning to make sure the incoming transaction group is well formed. This abstracts the pattern and provides a convenient way to mix in common fields to check.

This does not allow txn field arrays yet and no nice api to refer to other transactions in the group
