### PR TITLE
Add applications to `Account` class. Update `.toml`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [""]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pyteal = "^0.9.0"
-py-algorand-sdk = {git = "https://github.com/algorand/py-algorand-sdk.git", rev = "6ed0817f67903bb68d516e98f860e79b2839e06f"}
+pyteal = "^0.9.1"
+py-algorand-sdk = "^1.9.0"
 pytest = "^6.2.5"
 pytest-xdist = "^2.4.0"
 PyYAML = "^6.0"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,7 +4,7 @@ from base64 import b64decode
 from typing import List, Optional
 
 import algosdk.abi as sdkabi
-from algosdk import account, encoding, kmd, mnemonic
+from algosdk import account, encoding, kmd, logic, mnemonic
 from algosdk.future import transaction
 from algosdk.v2client import algod, indexer
 from pyteal import Cond, Expr, Int, Mode, Seq, Txn, compileTeal
@@ -42,18 +42,23 @@ class Account:
         address: str,
         private_key: Optional[str],
         lsig: Optional[transaction.LogicSig] = None,
+        app_id: Optional[int] = None,
     ):
         self.address = address
         self.private_key = private_key
         self.lsig = lsig
+        self.app_id = app_id
 
-        assert self.private_key or self.lsig
+        assert self.private_key or self.lsig or self.app_id
 
     def mnemonic(self) -> str:
         return mnemonic.from_private_key(self.private_key)
 
     def is_lsig(self) -> bool:
-        return bool(not self.private_key and self.lsig)
+        return bool(not self.private_key and not self.app_id and self.lsig)
+
+    def application_address(self) -> str:
+        return logic.get_application_address(self.app_id)
 
     @classmethod
     def create(cls) -> "Account":


### PR DESCRIPTION
With the addition of Application accounts the `Account` class should allow the creation of an account associated to an `app_id` with no `private_key` nor `lsig`. Project `.toml` can be updated with stable latest releases for `pyteal` (0.9.1) and `py-algorand-sdk` (1.9.0).